### PR TITLE
Fix: Adapt canvas and frame sizes to actual webcam resolution

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,14 +12,20 @@ def initialise_camera():
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
     cap.set(cv2.CAP_PROP_FPS, CAMERA_FPS)
 
-    return cap
+    # Getting the actual dimensions of the camera (if it ignores the above set)
+    actual_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    actual_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    print(f"Camera running at: {actual_width}x{actual_height}")
+
+    return cap, actual_width, actual_height
 
 def main():
-    cap = initialise_camera()
+    cap, cam_width, cam_height = initialise_camera()
     tracker = HandTracker()
     gesture_recogniser = GestureRecogniser()
-    canvas = DrawingCanvas(CAMERA_WIDTH, CAMERA_HEIGHT)
-    ui_manager = UIManager(CAMERA_WIDTH, CAMERA_HEIGHT)
+    canvas = DrawingCanvas(cam_width, cam_height)
+    ui_manager = UIManager(cam_width, cam_height)
     
     # Set initial colour
     canvas.set_colour(ui_manager.selected_colour)
@@ -93,6 +99,14 @@ def main():
         # Only show camera feed where there is no drawing
         mask = cv2.cvtColor(drawing_display, cv2.COLOR_BGR2GRAY)
         mask = cv2.threshold(mask, 1, 255, cv2.THRESH_BINARY)[1]
+
+        # Ensure mask is uint8
+        if mask.dtype != np.uint8:
+            mask = mask.astype(np.uint8)
+
+        # Ensure mask is the same size as the frame
+        if mask.shape != frame.shape[:2]:
+            mask = cv2.resize(mask, (frame.shape[1], frame.shape[0]))
         
         # Combine the camera feed and drawing
         frame_bg = cv2.bitwise_and(frame, frame, mask=cv2.bitwise_not(mask))


### PR DESCRIPTION
### Motivation  
I discovered this project on LinkedIn and found it very interesting, so I cloned it to explore and study the code.  
However, on my notebook, the webcam resolution didn’t match the fixed values defined in the code. This mismatch caused OpenCV runtime errors when combining the camera feed with the drawing canvas.

### What this PR does
- Updates camera initialization to retrieve the actual resolution after attempting to set it via OpenCV.  
- Passes the real resolution to `DrawingCanvas` and `UIManager` to ensure consistent dimensions across all components.  
- Adds type and shape validation to the mask used in `cv2.bitwise_and()` to prevent runtime crashes.

### Why this matters
This change improves compatibility and stability, ensuring the application works reliably across systems and webcams with different native resolutions.  
It makes the project easier for others to clone and run without needing manual adjustments.

### System tested on
- Ubuntu 24.04  
- Python 3.12  
- OpenCV 4.11

---

I really enjoyed exploring the code — great work on putting this together! I'm happy to contribute and would be glad to help with future improvements or features if needed. 😊
